### PR TITLE
Remove RPS and add ASL alphabet model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ComputeVisionRemote
 
-Este repositorio contiene un ejemplo de sistema de ComputeVision remota dividido en dos partes:
+Este repositorio contiene un ejemplo de sistema de reconocimiento de señas ASL estáticas dividido en dos partes:
 
-- **backend**: servidor Python que recibe imágenes por WebSocket, detecta manos mediante [MediaPipe](https://google.github.io/mediapipe/) y devuelve las coordenadas, topología de los keypoints y la letra de ASL reconocida.
+- **backend**: servidor Python que recibe imágenes por WebSocket, detecta manos mediante [MediaPipe](https://google.github.io/mediapipe/), clasifica la seña y devuelve las coordenadas, topología y la letra de ASL reconocida (A–Z).
 - **frontend**: Aplicación Android que captura la cámara del teléfono, envía cada fotograma al backend y dibuja los puntos recibidos desde el backend en la pantalla.
 
 ## Estructura
@@ -20,6 +20,7 @@ Este repositorio contiene un ejemplo de sistema de ComputeVision remota dividido
 | `app.py`           | Punto de entrada del servidor. Expone un WebSocket en `/ws` que recibe fotogramas JPEG, ejecuta la detección de manos con MediaPipe y envía las coordenadas, topología y la letra de ASL detectada en formato JSON. |
 | `hand_tracker.py`  | Utilidad para dibujar los keypoints sobre un fotograma usando las herramientas de dibujo de MediaPipe. Es opcional y sirve como código de apoyo para pruebas locales.|
 | `client_test.py`   | Cliente de ejemplo que se conecta al WebSocket, envía la imagen capturada desde la cámara del PC y muestra en consola la respuesta recibida.|
+| `train_model.py`   | Script para entrenar un modelo de clasificación de ASL usando el dataset de imágenes de [Kaggle](https://www.kaggle.com/datasets/grassknoted/asl-alphabet/data). |
 | `requirements.txt` | Lista de dependencias de Python necesarias para ejecutar el servidor. |
 
 ## Requisitos
@@ -39,7 +40,13 @@ Este repositorio contiene un ejemplo de sistema de ComputeVision remota dividido
    ```bash
    pip install -r requirements.txt
    ```
-3. Iniciar el servidor:
+3. (Opcional) Entrenar un modelo si no se dispone de `asl_model.pkl`. Descargue el
+   dataset desde [Kaggle](https://www.kaggle.com/datasets/grassknoted/asl-alphabet/data)
+   y descomprímalo. Luego ejecute:
+   ```bash
+   python train_model.py /ruta/al/asl_alphabet_train asl_model.pkl
+   ```
+4. Iniciar el servidor:
    ```bash
    python app.py
    ```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,6 @@ flask-sock
 opencv-python
 mediapipe
 numpy
+pandas
+scikit-learn
+

--- a/backend/train_model.py
+++ b/backend/train_model.py
@@ -1,0 +1,63 @@
+"""Training script for the ASL alphabet model."""
+
+import os
+import sys
+import pickle
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+LETTERS: List[str] = [chr(c) for c in range(ord("A"), ord("Z") + 1)]
+
+
+def _load_images(data_dir: str) -> Tuple[np.ndarray, np.ndarray]:
+    """Load images from the Kaggle ASL Alphabet dataset.
+
+    The expected directory structure is ``data_dir/A``, ``data_dir/B`` ...
+    containing JPEG or PNG images for each letter. Only the 26 letters are
+    used; other directories are ignored.
+    """
+
+    features: List[np.ndarray] = []
+    labels: List[str] = []
+
+    for letter in LETTERS:
+        letter_dir = os.path.join(data_dir, letter)
+        if not os.path.isdir(letter_dir):
+            print(f"Warning: directory '{letter_dir}' not found; skipping")
+            continue
+
+        for fname in os.listdir(letter_dir):
+            if not fname.lower().endswith((".jpg", ".jpeg", ".png")):
+                continue
+            path = os.path.join(letter_dir, fname)
+            img = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+            if img is None:
+                continue
+            img = cv2.resize(img, (64, 64))
+            features.append(img.flatten() / 255.0)
+            labels.append(letter)
+
+    return np.array(features), np.array(labels)
+
+
+def main(dataset_dir: str, out_model: str) -> None:
+    """Train a simple logistic regression model using the Kaggle dataset."""
+
+    X, y = _load_images(dataset_dir)
+    if len(X) == 0:
+        raise SystemExit("Dataset is empty or path is incorrect")
+
+    clf = LogisticRegression(max_iter=1000)
+    clf.fit(X, y)
+    with open(out_model, 'wb') as f:
+        pickle.dump(clf, f)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print('Usage: python train_model.py /path/to/asl_alphabet_train asl_model.pkl')
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- strip rock/paper/scissors heuristics from backend
- load ASL classifier from `asl_model.pkl`
- add `train_model.py` and scikit-learn/pandas to requirements
- update README with new ASL description and training instructions
- modify training script to use Kaggle image dataset

## Testing
- `python -m py_compile backend/app.py backend/client_test.py backend/train_model.py`
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68588c9ba5308326aa2c9a936135011b