### PR TITLE
Fix MediaPipe ROI warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Este repositorio contiene un ejemplo de sistema de reconocimiento de señas ASL 
 - Python 3.8 o superior para el backend
 - Android Studio (o las herramientas de Android SDK) para compilar la app
 
+**Nota**: el servidor recorta cada fotograma a un cuadro central antes de
+procesarlo con MediaPipe. Esto evita advertencias en versiones recientes de
+MediaPipe cuando la imagen de entrada no es cuadrada.
+
 ## Puesta en marcha del backend
 
 1. Crear un entorno virtual y activar:

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,6 +16,17 @@ hands = mp_hands.Hands(static_image_mode=False,
                        min_detection_confidence=0.5,
                        min_tracking_confidence=0.5)
 
+
+def _center_crop_square(img: "np.ndarray") -> "np.ndarray":
+    """Return a square crop centered in the image."""
+    h, w = img.shape[:2]
+    if h == w:
+        return img
+    side = min(h, w)
+    y0 = (h - side) // 2
+    x0 = (w - side) // 2
+    return img[y0 : y0 + side, x0 : x0 + side]
+
 DEFAULT_TOPOLOGY = [
     (
         c[0].value if hasattr(c[0], "value") else c[0],
@@ -67,6 +78,9 @@ def process_video(ws):
             frame = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
             if frame is None:
                 continue
+
+            # Normalize aspect ratio to a square image to avoid MediaPipe warnings
+            frame = _center_crop_square(frame)
 
             # Convertir a RGB
             image_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)

--- a/backend/train_model.py
+++ b/backend/train_model.py
@@ -13,6 +13,17 @@ from sklearn.linear_model import LogisticRegression
 LETTERS: List[str] = [chr(c) for c in range(ord("A"), ord("Z") + 1)]
 
 
+def _center_crop_square(img: np.ndarray) -> np.ndarray:
+    """Return a square crop of the given image."""
+    h, w = img.shape[:2]
+    if h == w:
+        return img
+    side = min(h, w)
+    y0 = (h - side) // 2
+    x0 = (w - side) // 2
+    return img[y0 : y0 + side, x0 : x0 + side]
+
+
 def _extract_features(hand_landmarks) -> List[float]:
     """Return a flat list of x, y, z coordinates from hand landmarks."""
     feats: List[float] = []
@@ -46,6 +57,7 @@ def _load_dataset(data_dir: str) -> Tuple[np.ndarray, np.ndarray]:
                 img = cv2.imread(path)
                 if img is None:
                     continue
+                img = _center_crop_square(img)
                 img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
                 results = hands.process(img_rgb)
                 if not results.multi_hand_landmarks:


### PR DESCRIPTION
## Summary
- crop frames to a center square before running MediaPipe
- apply same cropping during model training
- document the new behaviour in README

## Testing
- `python -m py_compile backend/app.py backend/train_model.py backend/client_test.py`

------
https://chatgpt.com/codex/tasks/task_e_685aa0b9b6f48326852bbc9907b5b63f