### PR TITLE
Limit WebSocket backlog and display FPS

### DIFF
--- a/frontend/app/src/main/res/layout/activity_main.xml
+++ b/frontend/app/src/main/res/layout/activity_main.xml
@@ -26,6 +26,16 @@
         android:padding="8dp" />
 
     <TextView
+        android:id="@+id/fpsTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|top"
+        android:textColor="@android:color/holo_green_light"
+        android:text="0 fps"
+        android:textSize="16sp"
+        android:padding="8dp" />
+
+    <TextView
         android:id="@+id/letterTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- wait for the server to respond before sending the next frame
- show processing FPS on screen

## Testing
- `python -m py_compile backend/app.py`
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ac4a398848326a94fb314bada1aae