### PR TITLE
Fix FPS/latency overlay position on Android

### DIFF
--- a/frontend/app/src/main/res/layout/activity_main.xml
+++ b/frontend/app/src/main/res/layout/activity_main.xml
@@ -19,20 +19,24 @@
         android:id="@+id/delayTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="start|top"
+        android:layout_gravity="start|bottom"
+        android:layout_marginBottom="24dp"
         android:textColor="@android:color/holo_green_light"
         android:text="0 ms"
         android:textSize="16sp"
+        android:background="#66000000"
         android:padding="8dp" />
 
     <TextView
         android:id="@+id/fpsTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="end|top"
+        android:layout_gravity="end|bottom"
+        android:layout_marginBottom="24dp"
         android:textColor="@android:color/holo_green_light"
         android:text="0 fps"
         android:textSize="16sp"
+        android:background="#66000000"
         android:padding="8dp" />
 
     <TextView


### PR DESCRIPTION
## Summary
- Move FPS and delay indicators from top to bottom corners
- Add margin and translucent background to keep stats visible

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e6836f48326b35e64cb8557518a