### PR TITLE
Handle analyzer state on socket disconnect

### DIFF
--- a/frontend/app/src/main/java/com/example/computevisionremote/MainActivity.kt
+++ b/frontend/app/src/main/java/com/example/computevisionremote/MainActivity.kt
@@ -258,6 +258,8 @@ class MainActivity : AppCompatActivity() {
 
     private fun disconnectSocket(userInitiated: Boolean = false) {
         shouldReconnect = !userInitiated
+        waitingForResponse.set(false)
+        sendTimes.clear()
         closeSocket()
     }
 
@@ -303,6 +305,8 @@ class MainActivity : AppCompatActivity() {
                 runOnUiThread {
                     Toast.makeText(this@MainActivity, "Connection closed", Toast.LENGTH_SHORT).show()
                 }
+                waitingForResponse.set(false)
+                sendTimes.clear()
                 if (shouldReconnect) {
                     reconnectWithBackoff()
                 }
@@ -319,6 +323,8 @@ class MainActivity : AppCompatActivity() {
                         Toast.LENGTH_SHORT
                     ).show()
                 }
+                waitingForResponse.set(false)
+                sendTimes.clear()
                 if (shouldReconnect) {
                     reconnectWithBackoff()
                 }


### PR DESCRIPTION
## Summary
- clear pending frames and waiting flags when disconnecting or on socket failures

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6a2ee65883269b8afe5a8e7f4392