### PR TITLE
Use float timestamps for metrics

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -36,7 +36,7 @@ GRAPHITE_PORT = int(os.getenv("GRAPHITE_PORT", "2003"))
 
 def send_metric(name: str, value: float) -> None:
     """Send a single metric to Graphite using the plaintext protocol."""
-    timestamp = int(time.time())
+    timestamp = time.time()
     message = f"{name} {value} {timestamp}\n"
     try:
         with socket.create_connection((GRAPHITE_HOST, GRAPHITE_PORT), timeout=1) as sock_conn:


### PR DESCRIPTION
## Summary
- send metrics with `time.time()` to preserve sub-second resolution

## Testing
- `bash metrics-stack-podman/up.sh` *(fails: podman: command not found)*
- `python - <<'PY'
... (local server test verifying unique decimal timestamps) ...
PY`
- `pytest` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8375e6e48326bb13fa30fd368049