### PR TITLE
Add retentions for Graphite delay metrics

### DIFF
--- a/metrics-stack-podman/graphite/storage-aggregation.conf
+++ b/metrics-stack-podman/graphite/storage-aggregation.conf
@@ -4,6 +4,11 @@ pattern = ^client\.delay_ms(;.*)?$
 xFilesFactor = 0.5
 aggregationMethod = average
 
+[mediapipe_asl_total_delay_last]
+pattern = ^(mediapipe|asl|total)\.delay_ms(;.*)?$
+xFilesFactor = 0
+aggregationMethod = last
+
 [default_average]
 pattern = .*
 xFilesFactor = 0.5

--- a/metrics-stack-podman/graphite/storage-schemas.conf
+++ b/metrics-stack-podman/graphite/storage-schemas.conf
@@ -1,7 +1,11 @@
 # Graphite retention policies
 [client_delay]
-pattern = ^client\.delay_ms(;.*)?$
+pattern = ^client\\.delay_ms(;.*)?$
 retentions = 10s:7d,1m:90d,10m:180d
+
+[mediapipe_asl_total_delay]
+pattern = ^(mediapipe|asl|total)\\.delay_ms(;.*)?$
+retentions = 1s:7d,10s:30d
 
 [default]
 pattern = .*


### PR DESCRIPTION
## Summary
- track mediapipe/asl/total delay metrics with a dedicated 1s retention policy
- preserve raw delay samples using `last` aggregation

## Testing
- `podman ps --filter name=metrics-stack` *(fails: command not found)*
- `systemctl restart graphite` *(fails: System has not been booted with systemd)*

------
https://chatgpt.com/codex/tasks/task_e_68ab84901f848326969f8f94617cd22f