### PR TITLE
Switch Telegraf output to InfluxDB v2

### DIFF
--- a/metrics-stack-podman/telegraf/android-metrics.conf
+++ b/metrics-stack-podman/telegraf/android-metrics.conf
@@ -1,4 +1,4 @@
-# Telegraf - HTTP ingest for Android client metrics -> Graphite (Podman pod)
+# Telegraf - HTTP ingest for Android client metrics -> InfluxDB v2 (Podman pod)
 [agent]
   interval = "10s"
   round_interval = true
@@ -24,10 +24,10 @@
   json_time_format = "unix_ms"
   tag_keys = ["session","fe","device","net","carrier","country","app_ver","build"]
 
-# Forward to Graphite (Carbon plaintext) - SAME POD NETWORK (localhost)
-[[outputs.graphite]]
-  servers = ["127.0.0.1:2003"]
-  timeout = "5s"
-  prefix  = "client"
-  graphite_tag_support = true
-  template = "measurement.tags.field"
+# Forward to InfluxDB v2 - SAME POD NETWORK (localhost)
+[[outputs.influxdb_v2]]
+  urls          = ["http://127.0.0.1:8086"]
+  token         = "example-token"
+  organization  = "example-org"
+  bucket        = "example-bucket"
+  precision     = "ms"


### PR DESCRIPTION
## Summary
- switch Telegraf configuration from Graphite to InfluxDB v2
- configure connection details and millisecond precision

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9068f56c832688eae51d627720f0