### PR TITLE
Switch Grafana to InfluxDB

### DIFF
--- a/metrics-stack-podman/grafana/dashboards/client-delay.json
+++ b/metrics-stack-podman/grafana/dashboards/client-delay.json
@@ -15,10 +15,10 @@
         "name": "session",
         "label": "session",
         "type": "query",
-        "datasource": "Graphite",
+        "datasource": "InfluxDB",
         "refresh": 2,
         "hide": 0,
-        "query": "tag_values('client.delay_ms','session')",
+        "query": "from(bucket: \"example-bucket\") |> range(start: -1h) |> filter(fn: (r) => r._measurement == \"client.delay_ms\") |> keep(columns: [\"session\"]) |> distinct(column: \"session\")",
         "multi": false,
         "includeAll": false
       },
@@ -26,10 +26,10 @@
         "name": "fe",
         "label": "fe",
         "type": "query",
-        "datasource": "Graphite",
+        "datasource": "InfluxDB",
         "refresh": 2,
         "hide": 0,
-        "query": "tag_values('client.delay_ms','fe')",
+        "query": "from(bucket: \"example-bucket\") |> range(start: -1h) |> filter(fn: (r) => r._measurement == \"client.delay_ms\") |> keep(columns: [\"fe\"]) |> distinct(column: \"fe\")",
         "multi": false,
         "includeAll": true,
         "allValue": ".*"
@@ -57,9 +57,10 @@
       },
       "targets": [
         {
-          "datasource": "Graphite",
+          "datasource": "InfluxDB",
           "refId": "A",
-          "target": "aliasByTags(seriesByTag('name=client.delay_ms','session=$session','fe=~$fe'), 'session','fe','device','net')"
+          "query": "from(bucket: \"example-bucket\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"client.delay_ms\" and r.session == \"${session}\" and r.fe =~ /${fe}/)\n  |> group(columns:[\"session\",\"fe\",\"device\",\"net\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)",
+          "queryType": "flux"
         }
       ],
       "fieldConfig": {
@@ -91,9 +92,10 @@
       },
       "targets": [
         {
-          "datasource": "Graphite",
+          "datasource": "InfluxDB",
           "refId": "B",
-          "target": "nPercentile(seriesByTag('name=client.delay_ms','session=$session','fe=~$fe'),95)"
+          "query": "from(bucket: \"example-bucket\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"client.delay_ms\" and r.session == \"${session}\" and r.fe =~ /${fe}/)\n  |> quantile(q: 0.95)",
+          "queryType": "flux"
         }
       ],
       "fieldConfig": {
@@ -121,9 +123,10 @@
       },
       "targets": [
         {
-          "datasource": "Graphite",
+          "datasource": "InfluxDB",
           "refId": "C",
-          "target": "averageSeries(seriesByTag('name=client.delay_ms','session=$session','fe=~$fe'))"
+          "query": "from(bucket: \"example-bucket\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"client.delay_ms\" and r.session == \"${session}\" and r.fe =~ /${fe}/)\n  |> mean()",
+          "queryType": "flux"
         }
       ],
       "fieldConfig": {
@@ -151,9 +154,10 @@
       },
       "targets": [
         {
-          "datasource": "Graphite",
+          "datasource": "InfluxDB",
           "refId": "D",
-          "target": "maxSeries(seriesByTag('name=client.delay_ms','session=$session','fe=~$fe'))"
+          "query": "from(bucket: \"example-bucket\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"client.delay_ms\" and r.session == \"${session}\" and r.fe =~ /${fe}/)\n  |> max()",
+          "queryType": "flux"
         }
       ],
       "fieldConfig": {

--- a/metrics-stack-podman/grafana/provisioning/datasources/graphite.yml
+++ b/metrics-stack-podman/grafana/provisioning/datasources/graphite.yml
@@ -1,9 +1,0 @@
-apiVersion: 1
-
-datasources:
-  - name: Graphite
-    type: graphite
-    access: proxy
-    url: http://127.0.0.1:8080
-    isDefault: true
-    editable: true

--- a/metrics-stack-podman/grafana/provisioning/datasources/influxdb.yml
+++ b/metrics-stack-podman/grafana/provisioning/datasources/influxdb.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    isDefault: true
+    editable: true
+    jsonData:
+      organization: example-org
+      defaultBucket: example-bucket
+      httpMode: POST
+    secureJsonData:
+      token: example-token


### PR DESCRIPTION
## Summary
- add InfluxDB datasource provisioning for Grafana
- migrate client-delay dashboard to Flux queries
- remove legacy Graphite datasource

## Testing
- `pytest` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9294864483269eb3c5bfd37187cd