### PR TITLE
Use InfluxDB datasource in Grafana dashboards

### DIFF
--- a/metrics-stack-podman/grafana/dashboards/client-delay.json
+++ b/metrics-stack-podman/grafana/dashboards/client-delay.json
@@ -15,7 +15,10 @@
         "name": "session",
         "label": "session",
         "type": "query",
-        "datasource": "InfluxDB",
+        "datasource": {
+          "type": "influxdb",
+          "uid": "InfluxDB"
+        },
         "refresh": 2,
         "hide": 0,
         "query": "from(bucket: \"example-bucket\") |> range(start: -1h) |> filter(fn: (r) => r._measurement == \"client.delay_ms\") |> keep(columns: [\"session\"]) |> distinct(column: \"session\")",
@@ -26,7 +29,10 @@
         "name": "fe",
         "label": "fe",
         "type": "query",
-        "datasource": "InfluxDB",
+        "datasource": {
+          "type": "influxdb",
+          "uid": "InfluxDB"
+        },
         "refresh": 2,
         "hide": 0,
         "query": "from(bucket: \"example-bucket\") |> range(start: -1h) |> filter(fn: (r) => r._measurement == \"client.delay_ms\") |> keep(columns: [\"fe\"]) |> distinct(column: \"fe\")",
@@ -57,7 +63,10 @@
       },
       "targets": [
         {
-          "datasource": "InfluxDB",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "InfluxDB"
+          },
           "refId": "A",
           "query": "from(bucket: \"example-bucket\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"client.delay_ms\" and r.session == \"${session}\" and r.fe =~ /${fe}/)\n  |> group(columns:[\"session\",\"fe\",\"device\",\"net\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)",
           "queryType": "flux"
@@ -92,7 +101,10 @@
       },
       "targets": [
         {
-          "datasource": "InfluxDB",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "InfluxDB"
+          },
           "refId": "B",
           "query": "from(bucket: \"example-bucket\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"client.delay_ms\" and r.session == \"${session}\" and r.fe =~ /${fe}/)\n  |> quantile(q: 0.95)",
           "queryType": "flux"
@@ -123,7 +135,10 @@
       },
       "targets": [
         {
-          "datasource": "InfluxDB",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "InfluxDB"
+          },
           "refId": "C",
           "query": "from(bucket: \"example-bucket\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"client.delay_ms\" and r.session == \"${session}\" and r.fe =~ /${fe}/)\n  |> mean()",
           "queryType": "flux"
@@ -154,7 +169,10 @@
       },
       "targets": [
         {
-          "datasource": "InfluxDB",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "InfluxDB"
+          },
           "refId": "D",
           "query": "from(bucket: \"example-bucket\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"client.delay_ms\" and r.session == \"${session}\" and r.fe =~ /${fe}/)\n  |> max()",
           "queryType": "flux"


### PR DESCRIPTION
## Summary
- rewrite Grafana dashboard panels to reference the InfluxDB datasource

## Testing
- `bash metrics-stack-podman/up.sh` *(fails: podman: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9e3d06f083268a015a843b95598a