### PR TITLE
Fix Grafana datasource to connect to InfluxDB in podman pod

### DIFF
--- a/metrics-stack-podman/grafana/provisioning/datasources/influxdb.yml
+++ b/metrics-stack-podman/grafana/provisioning/datasources/influxdb.yml
@@ -4,10 +4,11 @@ datasources:
   - name: InfluxDB
     type: influxdb
     access: proxy
-    url: http://influxdb:8086
+    url: http://127.0.0.1:8086
     isDefault: true
     editable: true
     jsonData:
+      version: Flux
       organization: example-org
       defaultBucket: example-bucket
       httpMode: POST


### PR DESCRIPTION
## Summary
- Point Grafana's InfluxDB datasource at localhost rather than the container name
- Enable Flux queries in the datasource configuration

## Testing
- `yamllint metrics-stack-podman/grafana/provisioning/datasources/influxdb.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_68ab82b5f06c8326bf9825454eb7d183