### PR TITLE
Add requests dependency and retry logic for metrics client

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,6 +32,7 @@ pycparser==2.22
 pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 pytz==2025.2
+requests==2.32.3
 scikit-learn==1.7.0
 scipy==1.16.0
 sentencepiece==0.2.0


### PR DESCRIPTION
## Summary
- add `requests` to backend requirements
- send metrics through a `requests` session with retry/backoff

## Testing
- `pip install requests==2.32.3` *(fails: Could not find a version that satisfies the requirement requests==2.32.3)*
- `python -m py_compile backend/metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68abae36d96c832698055d0430cc946d