### PR TITLE
Add backend Telegraf config for bursty metrics

### DIFF
--- a/metrics-stack-podman/README-PODMAN.md
+++ b/metrics-stack-podman/README-PODMAN.md
@@ -99,6 +99,15 @@ Configurar Telegraf para enviar a InfluxDB:
   bucket = "example-bucket"
 ```
 
+### Métricas del backend
+El archivo `telegraf/backend-metrics.conf` expone un `[[inputs.http_listener_v2]]` en el puerto **8090** para recibir métricas del backend.
+El agente usa `flush_interval = "1s"` y un `metric_buffer_limit = 50000` para tolerar ráfagas de tráfico.
+Luego de modificar esta configuración recargá Telegraf:
+
+```bash
+sudo systemctl reload telegraf
+```
+
 ## 9) SELinux (Fedora/RHEL)
 Si tenés SELinux en *enforcing*, etiquetá las carpetas montadas para que los contenedores puedan acceder:
 ```bash

--- a/metrics-stack-podman/telegraf/backend-metrics.conf
+++ b/metrics-stack-podman/telegraf/backend-metrics.conf
@@ -1,0 +1,34 @@
+# Telegraf - HTTP ingest for backend metrics -> InfluxDB v2 (Podman pod)
+[agent]
+  interval = "10s"
+  round_interval = true
+  flush_interval = "1s"
+  metric_buffer_limit = 50000
+  flush_jitter = "0s"
+  collection_jitter = "0s"
+  debug = false
+  quiet = false
+  logfile = ""
+
+# HTTP JSON ingestion for backend metrics
+[[inputs.http_listener_v2]]
+  service_address = ":8090"
+  paths = ["/backend"]
+  methods = ["POST"]
+  read_timeout  = "10s"
+  write_timeout = "10s"
+  max_body_size = "5MB"
+  data_source = "body"
+  data_format = "json"
+  json_name_key    = "measurement"
+  json_time_key    = "ts"
+  json_time_format = "unix_ms"
+  tag_keys = ["instance","service"]
+
+# Forward to InfluxDB v2 - SAME POD NETWORK (localhost)
+[[outputs.influxdb_v2]]
+  urls          = ["http://127.0.0.1:8086"]
+  token         = "example-token"
+  organization  = "example-org"
+  bucket        = "example-bucket"
+  precision     = "ms"


### PR DESCRIPTION
## Summary
- add backend-metrics.conf with 1s flush interval and large buffer
- document backend metrics listener and reload instructions

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `sudo systemctl reload telegraf` *(fails: System has not been booted with systemd as init system)*

------
https://chatgpt.com/codex/tasks/task_e_68abb04a1484832682cc50839a9b8cbd