### PR TITLE
Drop RenderScript toolkit and add CPU YUV converter

### DIFF
--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -62,5 +62,4 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("org.java-websocket:Java-WebSocket:1.5.7")
-    implementation("androidx.renderscript:renderscript-toolkit:1.0.0")
 }


### PR DESCRIPTION
## Summary
- Remove unresolved `androidx.renderscript:renderscript-toolkit` dependency
- Replace RenderScript-based YUV converter with pure Kotlin implementation

## Testing
- `./gradlew app:dependencies --configuration releaseCompileClasspath`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abffd16ce48326b797afd06eb9121b