### PR TITLE
Reuse persistent NV21 buffer for image conversion

### DIFF
--- a/frontend/app/src/main/java/com/example/computevisionremote/MainActivity.kt
+++ b/frontend/app/src/main/java/com/example/computevisionremote/MainActivity.kt
@@ -61,6 +61,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var target: Size
 
     private val jpegOutputStream = ByteArrayOutputStream()
+    private lateinit var nv21Buffer: ByteArray
 
     private val CAMERA_PERMISSION_REQUEST_CODE = 101
 
@@ -189,6 +190,7 @@ class MainActivity : AppCompatActivity() {
             Size(640, 480)
         }
         this.target = target
+        nv21Buffer = ByteArray(target.width * target.height * 3 / 2)
 
         val preview = Preview.Builder()
             .setTargetResolution(target)
@@ -234,7 +236,7 @@ class MainActivity : AppCompatActivity() {
         val vPlane = image.planes[2]
 
         val expectedSize = width * height * 3 / 2
-        val nv21 = ByteArray(expectedSize)
+        val nv21 = nv21Buffer
         var offset = 0
 
         // ----- Copy Y plane row by row -----


### PR DESCRIPTION
## Summary
- Allocate a reusable NV21 buffer during camera setup
- Use the persistent buffer during YUV->JPEG conversion to avoid per-frame allocations

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac783ed41c8326aff011351442b840