### PR TITLE
Recycle rotated bitmaps to free memory

### DIFF
--- a/frontend/app/src/main/java/com/example/computevisionremote/MainActivity.kt
+++ b/frontend/app/src/main/java/com/example/computevisionremote/MainActivity.kt
@@ -318,6 +318,8 @@ class MainActivity : AppCompatActivity() {
             jpegOutputStream.reset()
             rotatedBitmap.compress(Bitmap.CompressFormat.JPEG, 80, jpegOutputStream)
             imageBytes = jpegOutputStream.toByteArray()
+            bitmap.recycle()
+            rotatedBitmap.recycle()
         }
 
         Log.d(TAG, "JPEG conversion completed - final bytes: ${imageBytes.size}")


### PR DESCRIPTION
## Summary
- recycle both original and rotated bitmaps after rotation to free resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7f818d488326aa1c885996c71389