### PR TITLE
Use separate low resolution for ImageAnalysis

### DIFF
--- a/frontend/app/src/main/java/com/example/computevisionremote/MainActivity.kt
+++ b/frontend/app/src/main/java/com/example/computevisionremote/MainActivity.kt
@@ -184,22 +184,28 @@ class MainActivity : AppCompatActivity() {
 
         val rotation = previewView.display.rotation
 
-        val target = if (rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270) {
+        val previewResolution = if (rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270) {
             Size(480, 640)
         } else {
             Size(640, 480)
         }
-        this.target = target
+        this.target = previewResolution
+
+        val analysisResolution = if (rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270) {
+            Size(240, 320)
+        } else {
+            Size(320, 240)
+        }
 
         val preview = Preview.Builder()
-            .setTargetResolution(target)
+            .setTargetResolution(previewResolution)
             .setTargetRotation(rotation)
             .build().also {
                 it.setSurfaceProvider(previewView.surfaceProvider)
             }
 
         val imageAnalysis = ImageAnalysis.Builder()
-            .setTargetResolution(target)
+            .setTargetResolution(analysisResolution)
             .setTargetRotation(rotation)
             .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
             .build()


### PR DESCRIPTION
## Summary
- Configure ImageAnalysis to use a fixed 320x240 resolution independent from the preview
- Keep preview at original resolution for better visual quality

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac82e00870832694460cf2f6b1269d