### PR TITLE
Add JNI libyuv conversion for YUV->NV21

### DIFF
--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -36,6 +36,12 @@ android {
     }
     buildFeatures {
         compose = true
+        prefab = true
+    }
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+        }
     }
 }
 
@@ -67,4 +73,5 @@ dependencies {
     implementation("androidx.camera:camera-lifecycle:1.3.1")
     // If you're using CameraView for previews
     implementation("androidx.camera:camera-view:1.3.1")
+    implementation("io.github.crow-misia:libyuv:0.1.3")
 }

--- a/frontend/app/src/main/cpp/CMakeLists.txt
+++ b/frontend/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.10)
+project(yuvconverter)
+
+add_library(yuvconverter SHARED yuv_converter.cpp)
+
+find_package(libyuv REQUIRED CONFIG)
+
+find_library(log-lib log)
+
+target_link_libraries(yuvconverter PRIVATE libyuv::libyuv ${log-lib})

--- a/frontend/app/src/main/cpp/yuv_converter.cpp
+++ b/frontend/app/src/main/cpp/yuv_converter.cpp
@@ -1,0 +1,46 @@
+#include <jni.h>
+#include <stdint.h>
+#include <libyuv.h>
+#include <memory>
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_example_computevisionremote_MainActivity_yuv420ToNv21(
+        JNIEnv* env,
+        jobject /* this */,
+        jobject yBuffer, jint yRowStride, jint yPixelStride,
+        jobject uBuffer, jint uRowStride, jint uPixelStride,
+        jobject vBuffer, jint vRowStride, jint vPixelStride,
+        jint width, jint height,
+        jobject nv21Buffer) {
+    uint8_t* y = static_cast<uint8_t*>(env->GetDirectBufferAddress(yBuffer));
+    uint8_t* u = static_cast<uint8_t*>(env->GetDirectBufferAddress(uBuffer));
+    uint8_t* v = static_cast<uint8_t*>(env->GetDirectBufferAddress(vBuffer));
+    uint8_t* nv21 = static_cast<uint8_t*>(env->GetDirectBufferAddress(nv21Buffer));
+    if (!y || !u || !v || !nv21) {
+        return;
+    }
+
+    size_t frameSize = width * height;
+    size_t chromaSize = frameSize / 4;
+    std::unique_ptr<uint8_t[]> tmpY(new uint8_t[frameSize]);
+    std::unique_ptr<uint8_t[]> tmpU(new uint8_t[chromaSize]);
+    std::unique_ptr<uint8_t[]> tmpV(new uint8_t[chromaSize]);
+
+    libyuv::Android420ToI420(
+            y, yRowStride,
+            u, uRowStride,
+            v, vRowStride,
+            uPixelStride,
+            tmpY.get(), width,
+            tmpU.get(), width / 2,
+            tmpV.get(), width / 2,
+            width, height);
+
+    libyuv::I420ToNV21(
+            tmpY.get(), width,
+            tmpU.get(), width / 2,
+            tmpV.get(), width / 2,
+            nv21, width,
+            nv21 + frameSize, width,
+            width, height);
+}


### PR DESCRIPTION
## Summary
- add native C++ module linked with libyuv
- expose JNI yuv420ToNv21 to Kotlin and use in imageProxyToBitmap
- wire up Gradle to build native code and depend on libyuv

## Testing
- `./gradlew app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9455e2b88326b3d67ba88289647b